### PR TITLE
Update docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,13 @@ RUN --mount=type=cache,target=/root/.npm \
 WORKDIR /app
 
 # Copy package.json and pnpm-lock.yaml into the image.
-COPY ["package.json", "pnpm-lock.yaml", "./"]
+COPY ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "./"]
 COPY ["./apps/api/package.json", "./apps/api/"]
+COPY ["./apps/docs/package.json", "./apps/docs/"]
 COPY ["./apps/frontend/package.json", "./apps/frontend/"]
-COPY ["./packages/eslint-config-custom/package.json", "./apps/packages/eslint-config-custom"]
+COPY ["./packages/eslint-config-custom/package.json", "./packages/eslint-config-custom/"]
+COPY ["./packages/tsconfig/package.json", "./packages/tsconfig/"]
+COPY ["./packages/ui/package.json", "./packages/ui/"]
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.local/share/pnpm/store to speed up subsequent builds.

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,7 +3,7 @@ import pino from "pino-http";
 
 const app = express();
 const logger = pino();
-const port = process.env.API_PORT as string;
+const port = (process.env.API_PORT || "3002") as string;
 
 app.use(logger);
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,16 +12,19 @@ services:
     build:
       context: .
     ports:
-      - 5000:5000
-    command: ["/bin/sh", "-c", "pnpm dev"]
+      - 3000:3000
+      - 3001:3001
+      - 3002:3002
+    command: [ "/bin/sh", "-c", "pnpm dev" ]
     volumes:
       - ./:/app
       - /app/node_modules
       - /app/apps/api/node_modules
+      - /app/apps/docs/node_modules
       - /app/apps/frontend/node_modules
       - /app/packages/eslint-config-custom/node_modules
+      - /app/packages/tsconfig/node_modules
       - /app/packages/ui/node_modules
-    volume_name: devsandbox-app
     # The section below defines a PostgreSQL
     # database that the application can use. `depends_on` tells Docker Compose to
     # start the database before your application. The `db-data` volume persists the
@@ -31,11 +34,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
   db:
     image: postgres:16.0-alpine3.18
-    container_name: devsandbox-pg
     restart: always
-    user: postgres
     volumes:
       - db-data:/var/lib/postgresql/data
     environment:
@@ -45,7 +47,11 @@ services:
     expose:
       - 5432
     healthcheck:
-      test: ["CMD", "pg_isready"]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -d $DATABASE_NAME -U $DATABASE_USER"
+        ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This PR updates the docker configuration to fix the issue where the container fails on startup due to missing node_modules. 

The issues are caused by some missing workspace packages(_docs_, _tsconfig_, _ui_) and the _pnpm-workspace.yaml_ not copied into the build container before the **RUN pnpm install**. This results in the (npm) modules for those packages to be unavailable in the runtime container.

It also includes a minor workaround to the API server (failing) attempt to starting on a `NaN` port if the `PORT` env variable is not set.